### PR TITLE
Persist chat memory

### DIFF
--- a/rag_pipeline/retriever.py
+++ b/rag_pipeline/retriever.py
@@ -109,6 +109,7 @@ def add_chat_memory(
             f"{conversation_id}_{timestamp}_assistant"
         ]
     )
+    chat_store.persist()
 
 
 def retrieve_chat_memory(


### PR DESCRIPTION
## Summary
- persist chat memory so chat history isn't lost after restart

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685735ef23508331a5191e3b432b5aa4