### PR TITLE
Remove redundant chat memory handling

### DIFF
--- a/deployment/app.py
+++ b/deployment/app.py
@@ -1,11 +1,10 @@
 # app.py
 from typing import List, Optional
-from uuid import uuid4
 
 from fastapi import FastAPI
 from pydantic import BaseModel
 
-from rag_pipeline.retriever import load_vectorstore, add_chat_memory, retrieve_chat_memory
+from rag_pipeline.retriever import load_vectorstore
 from rag_pipeline.rag_chain import rag_chat
 
 app = FastAPI()
@@ -39,15 +38,6 @@ async def chat_endpoint(req: ChatRequest):
         chat_k=req.chat_k,
         article_store=article_store,
         chat_store=chat_store,
-    )
-
-    # Save user question and assistant answer to memory
-    add_chat_memory(
-        chat_store=chat_store,
-        conversation_id=req.conversation_id,
-        user_id=req.user_id,
-        question=req.question,
-        answer=response["answer"]
     )
 
     return response


### PR DESCRIPTION
## Summary
- streamline the FastAPI handler
- chat logging is already performed in `rag_chat`

## Testing
- `python -m py_compile deployment/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685735ebecb0833193361463c4facef7