### PR TITLE
Switch to ChatOpenAI with .env key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # RAG - Financial News Q&A Agent
 
-A Python-based Retrieval-Augmented Generation (RAG) system designed to answer stock-related questions by scraping, processing, and embedding financial news articles. Showcases expertise in web scraping (Scrapy), data processing (pandas, NumPy), NLP embeddings (HuggingFace, LangChain), and semantic search (ChromaDB). Utilizes LLMs (Ollama) for generating structured, context-rich responses.
+A Python-based Retrieval-Augmented Generation (RAG) system designed to answer stock-related questions by scraping, processing, and embedding financial news articles. Showcases expertise in web scraping (Scrapy), data processing (pandas, NumPy), NLP embeddings (HuggingFace, LangChain), and semantic search (ChromaDB). Utilizes OpenAI's ChatGPT via LangChain for generating structured, context-rich responses.
 
 <img src="./Images/project_image.png" width="300" alt="Project Logo">
 
@@ -9,7 +9,7 @@ A Python-based Retrieval-Augmented Generation (RAG) system designed to answer st
 - **Web Scraping:** Scrapes and stores financial news articles (over 40,000+ saved) with metadata via a Scrapy Spider (`finnews_scraper/`).
 - **Data Processing & Chunking:** Cleans and slices articles into smaller chunks for efficient embeddings (`processed_chunks/`).
 - **Embeddings & Semantic Search:** Generates embeddings using HuggingFace models and stores vectors in ChromaDB (`chroma_store/`) for fast, relevant retrieval.
-- **RAG-based Q&A Agent:** Answers stock-related questions using an LLM (Ollama + LangChain).
+- **RAG-based Q&A Agent:** Answers stock-related questions using OpenAI's ChatGPT via LangChain.
 
 ## Sample Conversation 
 
@@ -145,13 +145,22 @@ main.py                      # Interactive terminal chat entry point
    pip install -r requirements.txt
    ```
 
-2. **Run the scraper**
+2. **Configure OpenAI**
+
+   Copy `.env.example` to `.env` and add your OpenAI API key:
+
+   ```bash
+   cp .env.example .env
+   # edit .env and set OPENAI_API_KEY
+   ```
+
+3. **Run the scraper**
 
    ```bash
    scrapy crawl finviz_news
    ```
 
-3. **Generate Chunks, embeddings & update vectorstore**
+4. **Generate Chunks, embeddings & update vectorstore**
 
    ```bash
    python chunker.py
@@ -161,7 +170,7 @@ main.py                      # Interactive terminal chat entry point
    python embedder.py
    ```
 
-4. **Start Q&A session**
+5. **Start Q&A session**
 
    ```bash
    python main.py

--- a/env.example
+++ b/env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and insert your OpenAI API key
+OPENAI_API_KEY=your-openai-api-key

--- a/rag_pipeline/rag_chain.py
+++ b/rag_pipeline/rag_chain.py
@@ -5,9 +5,12 @@ from datetime import datetime
 from typing import Optional
 from langchain_chroma import Chroma
 
+from dotenv import load_dotenv
 from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import RunnablePassthrough
-from langchain_ollama import OllamaLLM
+from langchain_openai import ChatOpenAI
+
+load_dotenv()
 
 from rag_pipeline.retriever import (
     load_vectorstore,
@@ -62,7 +65,8 @@ def rag_chat(
     )
 
 
-    llm = OllamaLLM(model="gemma3:4b", temperature=0.0)
+    api_key = os.getenv("OPENAI_API_KEY")
+    llm = ChatOpenAI(model="gpt-3.5-turbo", temperature=0.0, openai_api_key=api_key)
 
     chain = (
         {

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,9 @@ chromadb>=0.4.244
 # LLM and Transformers
 transformers>=4.38.0
 accelerate>=0.21.0
+langchain_openai>=0.1.0
+openai>=1.0.0
+python-dotenv>=1.0.0
 
 # Web Interface
 streamlit>=1.25.0


### PR DESCRIPTION
## Summary
- replace Ollama with `ChatOpenAI` in `rag_chain.py`
- load `OPENAI_API_KEY` from `.env`
- document OpenAI configuration in README
- add example environment file
- update requirements with `openai`, `langchain_openai` and `python-dotenv`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685742f768f48331899d5bb1f5e08fe6