### PR TITLE
Add initial unit tests

### DIFF
--- a/tests/test_chunker.py
+++ b/tests/test_chunker.py
@@ -1,0 +1,55 @@
+import sys
+import types
+import importlib
+from pathlib import Path
+
+import pytest
+
+# Ensure package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def import_chunker(monkeypatch):
+    class Document:
+        def __init__(self, page_content, metadata=None):
+            self.page_content = page_content
+            self.metadata = metadata or {}
+
+    class DummySplitter:
+        def __init__(self, *args, **kwargs):
+            pass
+        def create_documents(self, texts, metadatas=None):
+            docs = []
+            for text, meta in zip(texts, metadatas or [{}]):
+                for part in text.split('. '):
+                    part = part.strip()
+                    if part:
+                        docs.append(Document(part, meta))
+            return docs
+
+    ts_mod = types.ModuleType('langchain.text_splitter')
+    ts_mod.RecursiveCharacterTextSplitter = DummySplitter
+    schema_mod = types.ModuleType('langchain.schema')
+    schema_mod.Document = Document
+
+    monkeypatch.setitem(sys.modules, 'langchain.text_splitter', ts_mod)
+    monkeypatch.setitem(sys.modules, 'langchain.schema', schema_mod)
+
+    if 'rag_pipeline.chunker' in sys.modules:
+        del sys.modules['rag_pipeline.chunker']
+    return importlib.import_module('rag_pipeline.chunker')
+
+
+def test_chunk_articles_sentence_splitting(monkeypatch):
+    chunker = import_chunker(monkeypatch)
+
+    articles = [{
+        'title': 'T',
+        'url': 'u',
+        'body': 'First sentence. Second sentence. Third sentence.'
+    }]
+
+    docs = chunker.chunk_articles(articles, max_characters=10)
+    contents = [d.page_content for d in docs]
+    assert len(contents) == 3
+    assert contents[0].startswith('First')

--- a/tests/test_rag_chain.py
+++ b/tests/test_rag_chain.py
@@ -1,0 +1,86 @@
+import sys
+import types
+import importlib
+from datetime import datetime
+from pathlib import Path
+
+# Ensure package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def import_rag_chain(monkeypatch):
+    class Document:
+        def __init__(self, page_content, metadata=None):
+            self.page_content = page_content
+            self.metadata = metadata or {}
+
+    # stub modules needed at import
+    chroma_mod = types.ModuleType('langchain_chroma')
+    chroma_mod.Chroma = object
+    prompt_mod = types.ModuleType('langchain_core.prompts')
+    class DummyPrompt:
+        @classmethod
+        def from_template(cls, template):
+            class P:
+                def __ror__(self, other):
+                    return other
+            return P()
+    prompt_mod.PromptTemplate = DummyPrompt
+
+    runnable_mod = types.ModuleType('langchain_core.runnables')
+    class DummyPassthrough:
+        def __or__(self, other):
+            return lambda x: other(x)
+    runnable_mod.RunnablePassthrough = DummyPassthrough
+
+    llm_mod = types.ModuleType('langchain_ollama')
+    class DummyLLM:
+        def __init__(self, *a, **k):
+            pass
+        def __ror__(self, other):
+            class C:
+                def invoke(self_inner, q):
+                    return 'dummy answer'
+            return C()
+    llm_mod.OllamaLLM = DummyLLM
+
+    monkeypatch.setitem(sys.modules, 'langchain_chroma', chroma_mod)
+    monkeypatch.setitem(sys.modules, 'langchain_core.prompts', prompt_mod)
+    monkeypatch.setitem(sys.modules, 'langchain_core.runnables', runnable_mod)
+    monkeypatch.setitem(sys.modules, 'langchain_ollama', llm_mod)
+
+    # patch retriever functions
+    class DummyStore:
+        pass
+
+    def fake_article_chunk_retriever(store, query, target_tickers=None, top_n=5):
+        return [Document('article', {'title':'T','url':'U','published_date': '2024-01-01'})]
+
+    def fake_retrieve_chat_memory(store, conversation_id, query, k=3):
+        return [Document('history', {})]
+
+    def fake_add_chat_memory(store, conversation_id, user_id, question, answer, model_name='x'):
+        pass
+
+    retr_mod = types.ModuleType('rag_pipeline.retriever')
+    retr_mod.load_vectorstore = lambda path, model_name='x': DummyStore()
+    retr_mod.article_chunk_retriever = fake_article_chunk_retriever
+    retr_mod.retrieve_chat_memory = fake_retrieve_chat_memory
+    retr_mod.add_chat_memory = fake_add_chat_memory
+    sys.modules['rag_pipeline.retriever'] = retr_mod
+    schema_mod = types.ModuleType('langchain.schema')
+    schema_mod.Document = Document
+    monkeypatch.setitem(sys.modules, 'langchain.schema', schema_mod)
+
+    if 'rag_pipeline.rag_chain' in sys.modules:
+        del sys.modules['rag_pipeline.rag_chain']
+    return importlib.import_module('rag_pipeline.rag_chain'), Document, DummyStore
+
+
+def test_rag_chat_answer_generation(monkeypatch):
+    rag_chain, Document, DummyStore = import_rag_chain(monkeypatch)
+
+    result = rag_chain.rag_chat('question', conversation_id='1', user_id='u', article_store=DummyStore(), chat_store=DummyStore())
+    assert result['answer'] == 'dummy answer'
+    assert result['conversation_id'] == '1'
+    assert result['sources'][0]['title'] == 'T'

--- a/tests/test_retriever.py
+++ b/tests/test_retriever.py
@@ -1,0 +1,52 @@
+import sys
+import types
+import importlib
+from datetime import datetime
+from pathlib import Path
+
+# Ensure package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+
+def import_retriever(monkeypatch):
+    class Document:
+        def __init__(self, page_content, metadata=None):
+            self.page_content = page_content
+            self.metadata = metadata or {}
+
+    class DummyChroma:
+        def __init__(self, docs=None):
+            self.docs = docs or []
+        def as_retriever(self, search_kwargs=None):
+            docs = self.docs
+            class R:
+                def invoke(self, query):
+                    return docs
+            return R()
+
+    ts_mod = types.ModuleType('langchain_chroma')
+    ts_mod.Chroma = DummyChroma
+    hf_mod = types.ModuleType('langchain_huggingface')
+    hf_mod.HuggingFaceEmbeddings = lambda *a, **k: None
+    schema_mod = types.ModuleType('langchain.schema')
+    schema_mod.Document = Document
+
+    monkeypatch.setitem(sys.modules, 'langchain_chroma', ts_mod)
+    monkeypatch.setitem(sys.modules, 'langchain_huggingface', hf_mod)
+    monkeypatch.setitem(sys.modules, 'langchain.schema', schema_mod)
+
+    if 'rag_pipeline.retriever' in sys.modules:
+        del sys.modules['rag_pipeline.retriever']
+    return importlib.import_module('rag_pipeline.retriever'), Document, DummyChroma
+
+
+def test_article_chunk_retriever_top_k(monkeypatch):
+    retriever, Document, DummyChroma = import_retriever(monkeypatch)
+
+    now = datetime.now().isoformat()
+    docs = [Document('doc'+str(i), {'published_date': now}) for i in range(3)]
+    store = DummyChroma(docs)
+
+    results = retriever.article_chunk_retriever(store, 'query', top_n=2)
+    assert len(results) == 2
+    assert all(isinstance(d, Document) for d in results)


### PR DESCRIPTION
## Summary
- add pytest-based tests for chunker, retriever and rag_chain

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857431eee948331befa46d9c63eaab3